### PR TITLE
Fix @mapbox/react-native-mapbox-gl => @react-native-mapbox/maps

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -30,7 +30,7 @@ target 'RNMapboxGLExample' do
   pod 'Folly', :podspec => "#{rn_path}/third-party-podspecs/Folly.podspec"
 
   # Mapbox
-  pod 'react-native-mapbox-gl', :path => '../node_modules/@mapbox/react-native-mapbox-gl'
+  pod 'react-native-mapbox-gl', :path => '../node_modules/@react-native-mapbox/maps'
 
   # RN-Vector-Icons
   pod 'RNVectorIcons', :path => '../node_modules/react-native-vector-icons'

--- a/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
+++ b/example/ios/RNMapboxGLExample.xcodeproj/project.pbxproj
@@ -1291,7 +1291,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-RNMapboxGLExample/Pods-RNMapboxGLExample-frameworks.sh",
-				"${PODS_ROOT}/../../node_modules/@mapbox/react-native-mapbox-gl/ios/Mapbox.framework",
+				"${PODS_ROOT}/../../node_modules/@react-native-mapbox/maps/ios/Mapbox.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@mapbox/geo-viewport": "^0.4.0",
-    "@mapbox/react-native-mapbox-gl": "file:../mapbox-react-native-mapbox-gl-6.1.4.tgz",
+    "@react-native-mapbox/maps": "file:../react-native-mapbox-maps-7.0.0.tgz",
     "@turf/along": "^5.1.5",
     "@turf/bearing": "^5.1.5",
     "@turf/distance": "^5.1.5",

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 import {
   FlatList,
   Modal,

--- a/example/src/components/ChoroplethLayerByZoomLevel.js
+++ b/example/src/components/ChoroplethLayerByZoomLevel.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/CreateOfflineRegion.js
+++ b/example/src/components/CreateOfflineRegion.js
@@ -7,7 +7,7 @@ import {
   Dimensions,
   StyleSheet,
 } from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 import geoViewport from '@mapbox/geo-viewport';
 
 import sheet from '../styles/sheet';

--- a/example/src/components/CustomIcon.js
+++ b/example/src/components/CustomIcon.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import exampleIcon from '../assets/example.png';

--- a/example/src/components/CustomVectorSource.js
+++ b/example/src/components/CustomVectorSource.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/DataDrivenCircleColors.js
+++ b/example/src/components/DataDrivenCircleColors.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/DriveTheLine.js
+++ b/example/src/components/DriveTheLine.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 import {View, StyleSheet} from 'react-native';
 import {Button} from 'react-native-elements';
 import {lineString as makeLineString} from '@turf/helpers';

--- a/example/src/components/EarthQuakes.js
+++ b/example/src/components/EarthQuakes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import {SF_OFFICE_COORDINATE} from '../utils';

--- a/example/src/components/FitBounds.js
+++ b/example/src/components/FitBounds.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/FlyTo.js
+++ b/example/src/components/FlyTo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Alert} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/GeoJSONSource.js
+++ b/example/src/components/GeoJSONSource.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import gridPattern from '../assets/grid_pattern.png';

--- a/example/src/components/GetCenter.js
+++ b/example/src/components/GetCenter.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import BaseExamplePropTypes from './common/BaseExamplePropTypes';
 import Page from './common/Page';

--- a/example/src/components/GetZoom.js
+++ b/example/src/components/GetZoom.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import BaseExamplePropTypes from './common/BaseExamplePropTypes';
 import Page from './common/Page';

--- a/example/src/components/ImageOverlay.js
+++ b/example/src/components/ImageOverlay.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import radar0 from '../assets/radar.png';

--- a/example/src/components/IndoorBuilding.js
+++ b/example/src/components/IndoorBuilding.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View, StyleSheet} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 import {Slider} from 'react-native-elements';
 
 import sheet from '../styles/sheet';

--- a/example/src/components/PointInMapView.js
+++ b/example/src/components/PointInMapView.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import BaseExamplePropTypes from './common/BaseExamplePropTypes';
 import Page from './common/Page';

--- a/example/src/components/QueryAtPoint.js
+++ b/example/src/components/QueryAtPoint.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import nycJSON from '../assets/nyc_geojson.json';

--- a/example/src/components/QueryWithRect.js
+++ b/example/src/components/QueryWithRect.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import nycJSON from '../assets/nyc_geojson.json';

--- a/example/src/components/SetBearing.js
+++ b/example/src/components/SetBearing.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/SetPitch.js
+++ b/example/src/components/SetPitch.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/SetUserLocationVerticalAlignment.js
+++ b/example/src/components/SetUserLocationVerticalAlignment.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import {onSortOptions} from '../utils';

--- a/example/src/components/SetUserTrackingModes.js
+++ b/example/src/components/SetUserTrackingModes.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import {onSortOptions} from '../utils';

--- a/example/src/components/ShapeSourceIcon.js
+++ b/example/src/components/ShapeSourceIcon.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import exampleIcon from '../assets/example.png';

--- a/example/src/components/ShowClick.js
+++ b/example/src/components/ShowClick.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import {DEFAULT_CENTER_COORDINATE} from '../utils';

--- a/example/src/components/ShowMap.js
+++ b/example/src/components/ShowMap.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import {onSortOptions} from '../utils';

--- a/example/src/components/ShowPointAnnotation.js
+++ b/example/src/components/ShowPointAnnotation.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Animated, View, Text, StyleSheet} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/ShowRegionChange.js
+++ b/example/src/components/ShowRegionChange.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import {DEFAULT_CENTER_COORDINATE, SF_OFFICE_COORDINATE} from '../utils';

--- a/example/src/components/TakeSnapshot.js
+++ b/example/src/components/TakeSnapshot.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 import {
   View,
   Image,

--- a/example/src/components/TakeSnapshotWithMap.js
+++ b/example/src/components/TakeSnapshotWithMap.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {StyleSheet, View, Text, TouchableOpacity, Image} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import colors from '../styles/colors';

--- a/example/src/components/TwoByTwo.js
+++ b/example/src/components/TwoByTwo.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import smileyFaceGeoJSON from '../assets/smiley_face.json';

--- a/example/src/components/UserLocationChange.js
+++ b/example/src/components/UserLocationChange.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Text} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 

--- a/example/src/components/WatercolorRasterTiles.js
+++ b/example/src/components/WatercolorRasterTiles.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {View, StyleSheet} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 import {Slider} from 'react-native-elements';
 
 import sheet from '../styles/sheet';

--- a/example/src/components/YoYo.js
+++ b/example/src/components/YoYo.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 import sheet from '../styles/sheet';
 import colors from '../styles/colors';

--- a/example/src/components/common/PulseCircleLayer.js
+++ b/example/src/components/common/PulseCircleLayer.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {Animated} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 
 const styles = MapboxGL.StyleSheet.create({
   innerCircle: {

--- a/example/src/utils/RouteSimulator.js
+++ b/example/src/utils/RouteSimulator.js
@@ -1,5 +1,5 @@
 import {Animated} from 'react-native';
-import MapboxGL from '@mapbox/react-native-mapbox-gl';
+import MapboxGL from '@react-native-mapbox/maps';
 import along from '@turf/along';
 import findDistance from '@turf/distance';
 


### PR DESCRIPTION
Replaced old references from @mapbox/react-native-mapbox-gl  to @react-native-mapbox/maps. Allowed me to `npm install` then start the example on ios simulator.