### PR TITLE
Updated FitBounds for the new Camera api

### DIFF
--- a/example/src/examples/FitBounds.js
+++ b/example/src/examples/FitBounds.js
@@ -22,10 +22,24 @@ class FitBounds extends React.Component {
     ];
 
     this.onFitBounds = this.onFitBounds.bind(this);
+
+    this.state = {
+      bounds: {
+        ne: this.houseBounds[0],
+        sw: this.houseBounds[1],
+      },
+      animationDuration: 0,
+    };
   }
 
   onFitBounds(i, bounds) {
-    this.map.fitBounds(bounds[0], bounds[1], 0, 200); // ne sw
+    this.setState({
+      bounds: {
+        ne: bounds[0],
+        sw: bounds[1],
+      },
+      animationDuration: 2000,
+    });
   }
 
   render() {
@@ -36,13 +50,16 @@ class FitBounds extends React.Component {
         onOptionPress={this.onFitBounds}
       >
         <MapboxGL.MapView
-          ref={ref => (this.map = ref)}
           contentInset={10}
-          visibleCoordinateBounds={this.houseBounds}
-          maxZoomLevel={19}
           styleURL={MapboxGL.StyleURL.Satellite}
           style={sheet.matchParent}
-        />
+        >
+          <MapboxGL.Camera
+            bounds={this.state.bounds}
+            animationDuration={this.state.animationDuration}
+            maxZoomLevel={19}
+          />
+        </MapboxGL.MapView>
       </TabBarPage>
     );
   }


### PR DESCRIPTION
Updated FitBounds in the example app to the new Camera api. 

One issue on ios is that the initial visible bounds is set when the view is small (64x64) and as we resize we'll see much larger area. So `resize` after `set-bounds` is not same as `set-bounds` after `resize` which is not nice. Android seems to work.

I guess we could store where the last update to the camera came from and if it was from `Camera` properties, we need to reapply after view resize. (We need to at least implement https://github.com/nitaliano/react-native-mapbox-gl/pull/1255 , which only fixes the issue for iniital layout)

`resize` after `setbounds`:
![kép](https://user-images.githubusercontent.com/52435/57246510-bd22c800-703d-11e9-9dc4-d836a19887f5.png)


`set bound` after `resize`: 
![kép](https://user-images.githubusercontent.com/52435/57246361-64532f80-703d-11e9-816b-2cad7fb310c9.png)
