### PR TITLE
Reapply camera on initial layout 

### DIFF
--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
@@ -73,6 +73,9 @@ public class RCTMGLCamera extends AbstractMapFeature {
     private double mPitch;
     private double mZoomLevel;
 
+    private double mMinZoomLevel = -1;
+    private double mMaxZoomLevel = -1;
+
     private boolean mFollowUserLocation;
     private String mFollowUserMode;
 
@@ -132,6 +135,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
         if (mCameraStop != null) {
             updateCamera();
         }
+        updateMaxMinZoomLevel();
 
         if (mShowUserLocation) {
             enableLocation();
@@ -149,6 +153,18 @@ public class RCTMGLCamera extends AbstractMapFeature {
 
         if (mMapView != null) {
             updateCamera();
+        }
+    }
+
+    private void updateMaxMinZoomLevel() {
+        MapboxMap map = getMapboxMap();
+        if (map != null) {
+            if (mMinZoomLevel >= 0.0) {
+                map.setMinZoomPreference(mMinZoomLevel);
+            }
+            if (mMaxZoomLevel >= 0.0) {
+                map.setMaxZoomPreference(mMaxZoomLevel);
+            }
         }
     }
 
@@ -360,6 +376,16 @@ public class RCTMGLCamera extends AbstractMapFeature {
         if (userLayerMode != -1) {
             mLocationComponent.setRenderMode(userLayerMode);
         }
+    }
+
+    public void setMinZoomLevel(double zoomLevel) {
+        mMinZoomLevel = zoomLevel;
+        updateMaxMinZoomLevel();
+    }
+
+    public void setMaxZoomLevel(double zoomLevel) {
+        mMaxZoomLevel = zoomLevel;
+        updateMaxMinZoomLevel();
     }
 
     public void setZoomLevel(double zoomLevel) {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCameraManager.java
@@ -62,4 +62,15 @@ public class RCTMGLCameraManager extends AbstractEventEmitter<RCTMGLCamera> {
     public void setFollowUserMode(RCTMGLCamera camera, String value) {
         camera.setFollowUserMode(value);
     }
+
+    @ReactProp(name="minZoomLevel")
+    public void setMinZoomLevel(RCTMGLCamera camera, double value) {
+        camera.setMinZoomLevel(value);
+    }
+
+    @ReactProp(name="maxZoomLevel")
+    public void setMaxZoomLevel(RCTMGLCamera camera, double value) {
+        camera.setMaxZoomLevel(value);
+    }
+
 }

--- a/ios/RCTMGL/RCTMGLCamera.h
+++ b/ios/RCTMGL/RCTMGLCamera.h
@@ -24,6 +24,9 @@
 @property (nonatomic, copy) NSNumber *followPitch;
 @property (nonatomic, copy) NSNumber *followHeading;
 
+@property (nonatomic, copy) NSNumber *maxZoomLevel;
+@property (nonatomic, copy) NSNumber *minZoomLevel;
+
 @property (nonatomic, copy) NSString *alignment;
 @property (nonatomic, copy, readonly) NSNumber *cameraAnimationMode;
 

--- a/ios/RCTMGL/RCTMGLCameraManager.m
+++ b/ios/RCTMGL/RCTMGLCameraManager.m
@@ -28,6 +28,9 @@ RCT_EXPORT_VIEW_PROPERTY(followHeading, NSNumber)
 
 RCT_EXPORT_VIEW_PROPERTY(alignment, NSString)
 
+RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, NSNumber)
+RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, NSNumber)
+
 #pragma Methods
 
 - (BOOL)requiresMainQueueSetup

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -17,9 +17,14 @@
 
 @class CameraUpdateQueue;
 
+@protocol RCTMGLMapViewLayoutObserver<NSObject>
+- (void)initialLayout;
+@end
+
 @interface RCTMGLMapView : MGLMapView<RCTInvalidating>
 
 @property (nonatomic, strong) CameraUpdateQueue *cameraUpdateQueue;
+@property (nonatomic, weak) id<RCTMGLMapViewLayoutObserver> layoutObserver;
 @property (nonatomic, strong) NSMutableArray<id<RCTComponent>> *reactSubviews;
 @property (nonatomic, strong) NSMutableArray<RCTMGLSource*> *sources;
 @property (nonatomic, strong) NSMutableArray<RCTMGLPointAnnotation*> *pointAnnotations;

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -40,8 +40,10 @@ static double const M2PI = M_PI * 2;
     [super layoutSubviews];
     if (_pendingInitialLayout) {
         _pendingInitialLayout = NO;
-        // FMTODO
-        // [self.camera _updateCameraAfterInitialLayout];
+
+        if (self.layoutObserver) {
+            [self.layoutObserver initialLayout];
+        }
     }
 }
 

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -310,6 +310,8 @@ class Camera extends NativeBridgeComponent {
         followHeading={this.props.followHeading}
         followZoomLevel={this.props.followZoomLevel}
         stop={this._createStopConfig(props)}
+        maxZoomLevel={this.props.maxZoomLevel}
+        minZoomLevel={this.props.minZoomLevel}
       />
     );
   }


### PR DESCRIPTION
and suport Camera#minZoomLevel and Camera#maxZoomLevel on ios

ios part of nitaliano/react-native-mapbox-gl#1255 was lost during the merge, this fixes that, also adds minZoomLevel/maxZoomLevel to camera (both android and ios)

See #30