### PR TITLE
Ported SetUserTrackingModes to the new UserLocation/Camera api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Breaking changes:
 
 * isTelemeryEnbaled removed (as no longer supported on android) [#1](https://github.com/mfazekas/maps/pull/1)
-* Camera related attributes on Mapbox now have to specified on a camera object:
+* Camera related properties on MapView now have to specified on a camera object:
    ```jsx
    <MapView
       zoomLevel={8}
@@ -26,4 +26,31 @@
      />
    </MapView>
    ```
+* User tracking properties moved from MapView to Camera
+   ```jsx
+   <MapView
+      userTrackingMode={UserTrackingModes.Follow}
+      ...
+   >
+      ...
+   </MapView>
+   ```
+    
+   is now
+   
+   ```jsx
+   <MapView
+     ...
+   >
+     <Camera
+        followUserLocation=true
+        followUserMode="follow"
+     />
+   </MapView>
+   ``` 
+   The following properties were changed:
+   * MapView#userTrackingMode is now Camera#followUserMode and Camera#followUserLocation
+   * followUserMode is now a string with ('normal','compass','course'), and UserTrackingModes enum is deprecated
+   * MapView#onUserTrackingModeChange is now Camera#onUserTrackingModeChange and payload contains followUserMode and followUserLocation. 
+
 * TODO document all changes

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/components/camera/RCTMGLCamera.java
@@ -8,6 +8,7 @@ import com.mapbox.mapboxsdk.camera.CameraUpdate;
 import com.mapbox.mapboxsdk.camera.CameraUpdateFactory;
 import com.mapbox.mapboxsdk.geometry.LatLng;
 import com.mapbox.mapboxsdk.geometry.VisibleRegion;
+import com.mapbox.mapboxsdk.location.OnCameraTrackingChangedListener;
 import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 import com.mapbox.mapboxsdk.maps.MapboxMap;
@@ -32,7 +33,7 @@ import com.mapbox.rctmgl.location.UserTrackingMode;
 import com.mapbox.rctmgl.location.UserTrackingState;
 import com.mapbox.rctmgl.utils.GeoJSONUtils;
 
-import com.mapbox.mapboxsdk.R;
+import com.mapbox.rctmgl.R;
 
 import com.mapbox.rctmgl.events.constants.EventTypes;
 
@@ -64,14 +65,14 @@ public class RCTMGLCamera extends AbstractMapFeature {
 
     private LocationManager mLocationManager;
     private UserLocation mUserLocation;
-    private boolean mShowUserLocation;
+    private boolean mShowUserLocation = false;
 
     private Point mCenterCoordinate;
 
     private boolean mAnimated;
     private double mHeading;
     private double mPitch;
-    private double mZoomLevel;
+    private double mZoomLevel = -1;
 
     private double mMinZoomLevel = -1;
     private double mMaxZoomLevel = -1;
@@ -85,7 +86,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
     private LocationManager.OnUserLocationChange mLocationChangeListener = new LocationManager.OnUserLocationChange() {
         @Override
         public void onLocationChange(Location nextLocation) {
-            if (getMapboxMap() == null || mLocationComponent == null || !mShowUserLocation) {
+            if (getMapboxMap() == null || mLocationComponent == null || (!mShowUserLocation && !mFollowUserLocation)) {
                 return;
             }
 
@@ -137,7 +138,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
         }
         updateMaxMinZoomLevel();
 
-        if (mShowUserLocation) {
+        if (mShowUserLocation || mFollowUserLocation) {
             enableLocation();
         }
     }
@@ -180,7 +181,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
     }
 
     private void updateUserLocation(boolean isAnimated) {
-        if (!mShowUserLocation || mUserLocation.getTrackingMode() == UserTrackingMode.NONE) {
+        if ((!mShowUserLocation && !mFollowUserLocation) || mUserLocation.getTrackingMode() == UserTrackingMode.NONE) {
             return;
         }
 
@@ -244,11 +245,22 @@ public class RCTMGLCamera extends AbstractMapFeature {
         return center.getLatitude() != 0.0 && center.getLongitude() != 0.0;
     }
 
+    static final double minimumZoomLevelForUserTracking = 10.5;
+    static final double defaultZoomLevelForUserTracking = 14.0;
 
     private void updateUserLocationSignificantly(boolean isAnimated) {
         mUserTrackingState = UserTrackingState.BEGAN;
 
-        CameraUpdate cameraUpdate = CameraUpdateFactory.newCameraPosition(getUserLocationUpdateCameraPosition(mZoomLevel));
+        double zoom = mZoomLevel;
+        if (zoom < 0) {
+            double camerZoom = mMapView.getMapboxMap().getCameraPosition().zoom;
+            if (camerZoom < minimumZoomLevelForUserTracking) {
+                zoom = defaultZoomLevelForUserTracking;
+            } else {
+                zoom = camerZoom;
+            }
+        }
+        CameraUpdate cameraUpdate = CameraUpdateFactory.newCameraPosition(getUserLocationUpdateCameraPosition(zoom));
         MapboxMap.CancelableCallback cameraCallback = new MapboxMap.CancelableCallback() {
             @Override
             public void onCancel() {
@@ -293,32 +305,6 @@ public class RCTMGLCamera extends AbstractMapFeature {
         }
     }
 
-    public void setReactUserTrackingMode(int userTrackingMode) {
-        int oldTrackingMode = mUserTrackingMode;
-        mUserTrackingMode = userTrackingMode;
-        updateUserTrackingMode(userTrackingMode);
-
-        switch (mUserTrackingMode) {
-            case UserTrackingMode.NONE:
-                mUserTrackingState = UserTrackingState.POSSIBLE;
-                break;
-            case UserTrackingMode.FOLLOW:
-            case UserTrackingMode.FollowWithCourse:
-            case UserTrackingMode.FollowWithHeading:
-                if (oldTrackingMode == UserTrackingMode.NONE) {
-                    mUserTrackingState = UserTrackingState.POSSIBLE;
-                }
-                mShowUserLocation = true;
-                break;
-
-        }
-
-        if (mMapView != null) {
-            updateUserLocation(false);
-            updateLocationLayer(mMapView.getMapboxMap().getStyle());
-        }
-    }
-
     private void enableLocation() {
         if (!PermissionsManager.areLocationPermissionsGranted(mContext)) {
             return;
@@ -337,6 +323,7 @@ public class RCTMGLCamera extends AbstractMapFeature {
     }
 
     private void enableLocationComponent(@NonNull Style style) {
+        updateUserLocation(false);
         updateLocationLayer(style);
 
         Location lastKnownLocation = mLocationManager.getLastKnownLocation();
@@ -358,23 +345,67 @@ public class RCTMGLCamera extends AbstractMapFeature {
     private void updateLocationLayer(@NonNull Style style) {
         if (mLocationComponent == null) {
             mLocationComponent = getMapboxMap().getLocationComponent();
-        }
 
-        LocationComponentOptions locationComponentOptions = LocationComponentOptions.builder(mContext)
+            LocationComponentOptions.Builder builder = LocationComponentOptions.builder(mContext);
+            if (!mShowUserLocation) {
+                builder = builder
+                        .backgroundDrawable(R.drawable.empty)
+                        .backgroundDrawableStale(R.drawable.empty)
+                        .bearingDrawable(R.drawable.empty)
+                        .foregroundDrawable(R.drawable.empty)
+                        .foregroundDrawableStale(R.drawable.empty)
+                        .gpsDrawable(R.drawable.empty)
+                        .accuracyAlpha(0.0f);
+            }
+            LocationComponentOptions locationComponentOptions = builder.build();
+
+            LocationComponentActivationOptions locationComponentActivationOptions = LocationComponentActivationOptions
+                    .builder(mContext, style)
+                    .locationComponentOptions(locationComponentOptions)
                     .build();
-
-        LocationComponentActivationOptions locationComponentActivationOptions = LocationComponentActivationOptions
-                .builder(mContext, style)
-                .locationComponentOptions(locationComponentOptions)
-                .build();
-        mLocationComponent.activateLocationComponent(locationComponentActivationOptions);
-        mLocationComponent.setLocationEngine(mLocationManager.getEngine());
-
+            mLocationComponent.activateLocationComponent(locationComponentActivationOptions);
+            mLocationComponent.setLocationEngine(mLocationManager.getEngine());
+        }
         int userLayerMode = UserTrackingMode.getMapLayerMode(mUserLocation.getTrackingMode(), mShowUserLocation);
-        mLocationComponent.setLocationComponentEnabled(userLayerMode != -1);
+        mLocationComponent.setLocationComponentEnabled(mFollowUserLocation || mShowUserLocation);
 
         if (userLayerMode != -1) {
             mLocationComponent.setRenderMode(userLayerMode);
+        }
+        if (mFollowUserLocation) {
+            if (!mShowUserLocation) {
+                mLocationComponent.setRenderMode(RenderMode.GPS);
+            }
+            mLocationComponent.setCameraMode(UserTrackingMode.getCameraMode(mUserTrackingMode));
+            mLocationComponent.onStart();
+            mLocationComponent.addOnCameraTrackingChangedListener(
+                new OnCameraTrackingChangedListener() {
+                    @Override public void onCameraTrackingChanged(int currentMode) {
+                        int userTrackingMode = UserTrackingMode.NONE;
+                        switch (currentMode) {
+                            case CameraMode.NONE:
+                                userTrackingMode = UserTrackingMode.NONE;
+                                break;
+                            case CameraMode.TRACKING:
+                                userTrackingMode = UserTrackingMode.FOLLOW;
+                                break;
+                            case CameraMode.TRACKING_COMPASS:
+                                userTrackingMode = UserTrackingMode.FollowWithHeading;
+                                break;
+                            case CameraMode.TRACKING_GPS:
+                                userTrackingMode = UserTrackingMode.FollowWithCourse;
+                                break;
+                            default:
+                                userTrackingMode = UserTrackingMode.NONE;
+                        }
+                        updateUserTrackingMode(userTrackingMode);
+                    }
+                    @Override public void onCameraTrackingDismissed() {
+                    }
+                }
+            );
+        } else {
+            mLocationComponent.setCameraMode(CameraMode.NONE);
         }
     }
 
@@ -434,13 +465,14 @@ public class RCTMGLCamera extends AbstractMapFeature {
                 if (oldTrackingMode == UserTrackingMode.NONE) {
                     mUserTrackingState = UserTrackingState.POSSIBLE;
                 }
-                mShowUserLocation = true;
+                mShowUserLocation = false;
                 break;
 
         }
 
         if (getMapboxMap() != null) {
-            updateUserLocation(false);
+            updateUserLocation
+                    (false);
             updateLocationLayer(getMapboxMap().getStyle());
         }
     }
@@ -448,16 +480,20 @@ public class RCTMGLCamera extends AbstractMapFeature {
 
     public void setFollowUserLocation(boolean value) {
         mFollowUserLocation = value;
-        if (value) {
-            setUserTrackingMode(UserTrackingMode.FOLLOW);
-        } else {
-            setUserTrackingMode(UserTrackingMode.NONE);
-        }
+        updatedFollowUserMode();
     }
 
     public void setFollowUserMode(String mode) {
         mFollowUserMode = mode;
+        updatedFollowUserMode();
+    }
 
+    private void updatedFollowUserMode() {
+        if (mFollowUserLocation) {
+            setUserTrackingMode(UserTrackingMode.fromString(mFollowUserMode));
+        } else {
+            setUserTrackingMode(UserTrackingMode.NONE);
+        }
     }
 
     MapboxMap getMapboxMap() {

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/MapUserTrackingModeEvent.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/events/MapUserTrackingModeEvent.java
@@ -6,6 +6,7 @@ import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableMap;
 import com.mapbox.rctmgl.events.constants.EventKeys;
 import com.mapbox.rctmgl.events.constants.EventTypes;
+import com.mapbox.rctmgl.location.UserTrackingMode;
 
 /**
  * Created by nickitaliano on 12/19/17.
@@ -27,7 +28,9 @@ public class MapUserTrackingModeEvent extends AbstractEvent {
     @Override
     public WritableMap getPayload() {
         WritableMap payload = Arguments.createMap();
-        payload.putInt("userTrackingMode", mUserTrackingMode);
+        payload.putBoolean("followUserLocation", mUserTrackingMode != UserTrackingMode.NONE);
+        payload.putString("followUserMode", UserTrackingMode.toString(mUserTrackingMode));
+
         return payload;
     }
 }

--- a/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserTrackingMode.java
+++ b/android/rctmgl/src/main/java/com/mapbox/rctmgl/location/UserTrackingMode.java
@@ -4,6 +4,7 @@ package com.mapbox.rctmgl.location;
 import com.mapbox.mapboxsdk.plugins.locationlayer.modes.RenderMode;
 */
 
+import com.mapbox.mapboxsdk.location.modes.CameraMode;
 import com.mapbox.mapboxsdk.location.modes.RenderMode;
 
 /**
@@ -30,7 +31,46 @@ public class UserTrackingMode {
         }
     }
 
+    public static @CameraMode.Mode int getCameraMode(int mode) {
+        switch(mode) {
+            case NONE:
+                return CameraMode.NONE;
+            case FOLLOW:
+                return CameraMode.TRACKING;
+            case FollowWithCourse:
+                return CameraMode.TRACKING_GPS;
+            case FollowWithHeading:
+                return CameraMode.TRACKING_COMPASS;
+        }
+        return CameraMode.NONE;
+    }
+
     public static boolean isUserGesture(int reason) {
         return reason == 1 || reason == 2; // user gesture or animation
+    }
+
+    public static String toString(int value) {
+        switch (value) {
+            case UserTrackingMode.FOLLOW:
+                return "normal";
+            case UserTrackingMode.FollowWithCourse:
+                return "course";
+            case UserTrackingMode.FollowWithHeading:
+                return "compass";
+        }
+        return null;
+    }
+
+    public static int fromString(String value) {
+        switch (value) {
+            case "course":
+                return UserTrackingMode.FollowWithCourse;
+            case "normal":
+                return UserTrackingMode.FOLLOW;
+            case "compass":
+                return UserTrackingMode.FollowWithHeading;
+            default:
+                return UserTrackingMode.NONE;
+        }
     }
 }

--- a/example/src/examples/SetUserTrackingModes.js
+++ b/example/src/examples/SetUserTrackingModes.js
@@ -35,8 +35,8 @@ class SetUserTrackingModes extends React.Component {
 
     this.state = {
       showUserLocation: true,
-      userSelectedUserTrackingMode: this._trackingOptions[0].data,
-      currentTrackingMode: this._trackingOptions[0].data,
+      userSelectedUserTrackingMode: this._trackingOptions[3].data,
+      currentTrackingMode: this._trackingOptions[3].data,
     };
 
     this.onTrackingChange = this.onTrackingChange.bind(this);
@@ -78,6 +78,7 @@ class SetUserTrackingModes extends React.Component {
       <TabBarPage
         {...this.props}
         scrollable
+        initialIndex={3}
         options={this._trackingOptions}
         onOptionPress={this.onTrackingChange}
       >

--- a/example/src/examples/SetUserTrackingModes.js
+++ b/example/src/examples/SetUserTrackingModes.js
@@ -52,8 +52,8 @@ class SetUserTrackingModes extends React.Component {
   }
 
   onUserTrackingModeChange(e) {
-    const {userTrackingMode} = e.nativeEvent.payload;
-    this.setState({currentTrackingMode: userTrackingMode});
+    const {followUserMode, followUserLocation} = e.nativeEvent.payload;
+    this.setState({currentTrackingMode: followUserMode || 'none'});
   }
 
   onToggleUserLocation() {
@@ -89,8 +89,9 @@ class SetUserTrackingModes extends React.Component {
               this.state.userSelectedUserTrackingMode !== 'none'
             }
             followUserMode={
-              this.state.userSelectedUserTrackingMode !== 'none' ?
-                this.state.userSelectedUserTrackingMode : 'normal'
+              this.state.userSelectedUserTrackingMode !== 'none'
+                ? this.state.userSelectedUserTrackingMode
+                : 'normal'
             }
             onUserTrackingModeChange={this.onUserTrackingModeChange}
           />

--- a/example/src/examples/SetUserTrackingModes.js
+++ b/example/src/examples/SetUserTrackingModes.js
@@ -17,6 +17,7 @@ class SetUserTrackingModes extends React.Component {
   constructor(props) {
     super(props);
 
+    // eslint-disable-next-line fp/no-mutating-methods
     this._trackingOptions = Object.keys(MapboxGL.UserTrackingModes)
       .map(key => {
         return {
@@ -24,6 +25,12 @@ class SetUserTrackingModes extends React.Component {
           data: MapboxGL.UserTrackingModes[key],
         };
       })
+      .concat([
+        {
+          label: 'None',
+          data: 'none',
+        },
+      ])
       .sort(onSortOptions);
 
     this.state = {
@@ -74,12 +81,20 @@ class SetUserTrackingModes extends React.Component {
         options={this._trackingOptions}
         onOptionPress={this.onTrackingChange}
       >
-        <MapboxGL.MapView
-          showUserLocation={this.state.showUserLocation}
-          userTrackingMode={this.state.userSelectedUserTrackingMode}
-          onUserTrackingModeChange={this.onUserTrackingModeChange}
-          style={sheet.matchParent}
-        />
+        <MapboxGL.MapView style={sheet.matchParent}>
+          <MapboxGL.UserLocation visible={this.state.showUserLocation} />
+
+          <MapboxGL.Camera
+            followUserLocation={
+              this.state.userSelectedUserTrackingMode !== 'none'
+            }
+            followUserMode={
+              this.state.userSelectedUserTrackingMode !== 'none' ?
+                this.state.userSelectedUserTrackingMode : 'normal'
+            }
+            onUserTrackingModeChange={this.onUserTrackingModeChange}
+          />
+        </MapboxGL.MapView>
 
         <Bubble style={{bottom: 100}}>
           <Text>User Tracking Mode: {this.userTrackingModeText}</Text>

--- a/ios/RCTMGL/RCTMGLCamera.h
+++ b/ios/RCTMGL/RCTMGLCamera.h
@@ -5,7 +5,7 @@
 //  Created by Nick Italiano on 6/22/18.
 //  Copyright © 2018 Mapbox Inc. All rights reserved.
 //
-
+#import <React/RCTComponent.h>
 #import <UIKit/UIKit.h>
 
 @class RCTMGLMapView;
@@ -29,5 +29,7 @@
 
 @property (nonatomic, copy) NSString *alignment;
 @property (nonatomic, copy, readonly) NSNumber *cameraAnimationMode;
+
+@property (nonatomic, copy) RCTBubblingEventBlock onUserTrackingModeChange;
 
 @end

--- a/ios/RCTMGL/RCTMGLCameraManager.m
+++ b/ios/RCTMGL/RCTMGLCameraManager.m
@@ -31,6 +31,8 @@ RCT_EXPORT_VIEW_PROPERTY(alignment, NSString)
 RCT_EXPORT_VIEW_PROPERTY(maxZoomLevel, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(minZoomLevel, NSNumber)
 
+RCT_EXPORT_VIEW_PROPERTY(onUserTrackingModeChange, RCTBubblingEventBlock)
+
 #pragma Methods
 
 - (BOOL)requiresMainQueueSetup

--- a/ios/RCTMGL/RCTMGLEventTypes.m
+++ b/ios/RCTMGL/RCTMGLEventTypes.m
@@ -13,6 +13,8 @@
 NSString *const RCT_MAPBOX_EVENT_TAP = @"press";
 NSString *const RCT_MAPBOX_EVENT_LONGPRESS = @"longpress";
 
+NSString *const RCT_MAPBOX_USER_TRACKING_MODE_CHANGE = @"usertrackingmodechange";
+
 NSString *const RCT_MAPBOX_REGION_WILL_CHANGE_EVENT = @"regionwillchange";
 NSString *const RCT_MAPBOX_REGION_IS_CHANGING = @"regionischanging";
 NSString *const RCT_MAPBOX_REGION_DID_CHANGE = @"regiondidchange";

--- a/ios/RCTMGL/RCTMGLMapView.h
+++ b/ios/RCTMGL/RCTMGLMapView.h
@@ -17,14 +17,15 @@
 
 @class CameraUpdateQueue;
 
-@protocol RCTMGLMapViewLayoutObserver<NSObject>
+@protocol RCTMGLMapViewCamera<NSObject>
 - (void)initialLayout;
+- (void)didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated;
 @end
 
 @interface RCTMGLMapView : MGLMapView<RCTInvalidating>
 
 @property (nonatomic, strong) CameraUpdateQueue *cameraUpdateQueue;
-@property (nonatomic, weak) id<RCTMGLMapViewLayoutObserver> layoutObserver;
+@property (nonatomic, weak) id<RCTMGLMapViewCamera> reactCamera;
 @property (nonatomic, strong) NSMutableArray<id<RCTComponent>> *reactSubviews;
 @property (nonatomic, strong) NSMutableArray<RCTMGLSource*> *sources;
 @property (nonatomic, strong) NSMutableArray<RCTMGLPointAnnotation*> *pointAnnotations;
@@ -54,5 +55,6 @@
 - (NSArray<RCTMGLSource *> *)getAllTouchableSources;
 - (RCTMGLSource *)getTouchableSourceWithHighestZIndex:(NSArray<RCTMGLSource *> *)touchableSources;
 - (NSString *)takeSnap:(BOOL)writeToDisk;
+- (void)didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated;
 
 @end

--- a/ios/RCTMGL/RCTMGLMapView.m
+++ b/ios/RCTMGL/RCTMGLMapView.m
@@ -41,9 +41,7 @@ static double const M2PI = M_PI * 2;
     if (_pendingInitialLayout) {
         _pendingInitialLayout = NO;
 
-        if (self.layoutObserver) {
-            [self.layoutObserver initialLayout];
-        }
+        [   _reactCamera initialLayout];
     }
 }
 
@@ -313,6 +311,10 @@ static double const M2PI = M_PI * 2;
     for (RCTMGLSource *source in _sources) {
         source.map = nil;
     }
+}
+
+- (void)didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated {
+    [_reactCamera didChangeUserTrackingMode:mode animated:animated];
 }
 
 @end

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -17,6 +17,7 @@
 #import "CameraStop.h"
 #import "CameraUpdateQueue.h"
 #import "FilterParser.h"
+#import "RCTMGLUserLocation.h"
 
 @interface RCTMGLMapViewManager() <MGLMapViewDelegate>
 @end
@@ -362,7 +363,10 @@ RCT_EXPORT_METHOD(showAttribution:(nonnull NSNumber *)reactTag
 
 - (MGLAnnotationView *)mapView:(MGLMapView *)mapView viewForAnnotation:(id<MGLAnnotation>)annotation
 {
-    if ([annotation isKindOfClass:[RCTMGLPointAnnotation class]]) {
+    if ([annotation isKindOfClass:[MGLUserLocation class]] && mapView.userLocation != nil) {
+        return [[RCTMGLUserLocation sharedInstance] builtinUserAnnotation];
+    }
+    else if ([annotation isKindOfClass:[RCTMGLPointAnnotation class]]) {
         RCTMGLPointAnnotation *rctAnnotation = (RCTMGLPointAnnotation *)annotation;
         return [rctAnnotation getAnnotationView];
     }

--- a/ios/RCTMGL/RCTMGLMapViewManager.m
+++ b/ios/RCTMGL/RCTMGLMapViewManager.m
@@ -373,6 +373,12 @@ RCT_EXPORT_METHOD(showAttribution:(nonnull NSNumber *)reactTag
     return nil;
 }
 
+- (void)mapView:(MGLMapView *)mapView didChangeUserTrackingMode:(MGLUserTrackingMode)mode animated:(BOOL)animated
+{
+    RCTMGLMapView* reactMapView = ((RCTMGLMapView *) mapView);
+    [reactMapView didChangeUserTrackingMode:mode animated:animated];
+}
+
 - (void)mapView:(MGLMapView *)mapView didSelectAnnotation:(nonnull id<MGLAnnotation>)annotation
 {
     if ([annotation isKindOfClass:[RCTMGLPointAnnotation class]]) {

--- a/ios/RCTMGL/RCTMGLUserLocation.h
+++ b/ios/RCTMGL/RCTMGLUserLocation.h
@@ -1,0 +1,15 @@
+//
+//  RCTMGLUserLocation.h
+//  RCTMGL
+
+#import <Foundation/Foundation.h>
+#import <CoreLocation/CoreLocation.h>
+#import <Mapbox/MGLUserLocationAnnotationView.h>
+
+@interface RCTMGLUserLocation : NSObject
+
++ (id)sharedInstance;
+
+- (MGLUserLocationAnnotationView*)builtinUserAnnotation;
+
+@end

--- a/ios/RCTMGL/RCTMGLUserLocation.m
+++ b/ios/RCTMGL/RCTMGLUserLocation.m
@@ -1,0 +1,38 @@
+//
+//  RCTMGLUserLocation.m
+//  RCTMGL
+//
+
+#import "RCTMGLUserLocation.h"
+#import <Mapbox/MGLUserLocationAnnotationView.h>
+
+@interface HiddenUserLocationAnnotationView : MGLUserLocationAnnotationView
+
+@end
+
+@implementation HiddenUserLocationAnnotationView
+
+
+- (void)update {
+    self.frame = CGRectNull;
+}
+
+@end
+
+
+@implementation RCTMGLUserLocation : NSObject
+
++ (id)sharedInstance
+{
+    static RCTMGLUserLocation *userLocation = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ userLocation = [[self alloc] init]; });
+    return userLocation;
+}
+
+- (MGLUserLocationAnnotationView*)builtinUserAnnotation
+{
+    return [[HiddenUserLocationAnnotationView alloc] init];
+}
+
+@end

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -323,4 +323,10 @@ const RCTMGLCamera = requireNativeComponent(NATIVE_MODULE_NAME, Camera, {
   },
 });
 
+Camera.UserTrackingModes = {
+  Follow: 'normal',
+  FollowWithHeading: 'compass',
+  FollowWithCourse: 'course',
+};
+
 export default Camera;

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -88,6 +88,7 @@ class Camera extends NativeBridgeComponent {
 
     if (nextCamera.followUserLocation) {
       this.refs.camera.setNativeProps({
+        followUserMode: nextCamera.followUserMode,
         followPitch: nextCamera.followPitch || nextCamera.pitch,
         followHeading: nextCamera.followHeading || nextCamera.heading,
         followZoomLevel: nextCamera.followZoomLevel || nextCamera.zoomLevel,

--- a/javascript/components/Camera.js
+++ b/javascript/components/Camera.js
@@ -301,6 +301,10 @@ class Camera extends NativeBridgeComponent {
   render() {
     const props = Object.assign({}, this.props);
 
+    const callbacks = {
+      onUserTrackingModeChange: props.onUserTrackingModeChange,
+    };
+
     return (
       <RCTMGLCamera
         ref="camera"
@@ -312,6 +316,7 @@ class Camera extends NativeBridgeComponent {
         stop={this._createStopConfig(props)}
         maxZoomLevel={this.props.maxZoomLevel}
         minZoomLevel={this.props.minZoomLevel}
+        {...callbacks}
       />
     );
   }

--- a/javascript/components/UserLocation.js
+++ b/javascript/components/UserLocation.js
@@ -63,6 +63,8 @@ class UserLocation extends React.Component {
 
     onPress: PropTypes.func,
     onUpdate: PropTypes.func,
+
+    children: PropTypes.any,
   };
 
   static defaultProps = {
@@ -106,10 +108,30 @@ class UserLocation extends React.Component {
     }
 
     locationManager.addListener(this._onLocationUpdate);
+    this.setLocationManager({
+      running: this.needsLocationManagerRunning(),
+    });
+  }
+
+  locationManagerRunning = false;
+
+  setLocationManager({running}) {
+    if (this.locationManagerRunning !== running) {
+      if (running) {
+        locationManager.start();
+      } else {
+        locationManager.stop();
+      }
+    }
+  }
+
+  needsLocationManagerRunning() {
+    return this.props.onUpdate || this.props.visible;
   }
 
   componentWillUnmount() {
     locationManager.removeListener(this._onLocationUpdate);
+    this.setLocationManager({running: false});
   }
 
   _onLocationUpdate(location) {
@@ -140,6 +162,12 @@ class UserLocation extends React.Component {
       default:
         return this.props.children;
     }
+  }
+
+  componentDidUpdate() {
+    this.setLocationManager({
+      running: this.needsLocationManagerRunning(),
+    });
   }
 
   render() {

--- a/javascript/index.js
+++ b/javascript/index.js
@@ -60,6 +60,8 @@ MapboxGL.requestAndroidLocationPermissions = async function() {
   throw new Error('You should only call this method on Android!');
 };
 
+MapboxGL.UserTrackingModes = Camera.UserTrackingModes;
+
 // components
 MapboxGL.MapView = MapView;
 MapboxGL.Light = Light;


### PR DESCRIPTION
Also fixed erros on ios, android:

- Use an invisible user location annotation for builtin location annotation , so we can use our own annotation for location [ios/android]
- `UserLocation` starts/stops locationManager as needed. [javascript]
- implement `onUserTrackingModeChange`  (see https://github.com/nitaliano/react-native-mapbox-gl/pull/897 for original impl) [ios and android]

