### PR TITLE
Fix: rename rasterResampling to rasterResamplingMode

### DIFF
--- a/ios/RCTMGL/RCTMGLStyle.m
+++ b/ios/RCTMGL/RCTMGLStyle.m
@@ -1467,7 +1467,7 @@
 
 - (void)setRasterResampling:(MGLRasterStyleLayer *)layer withReactStyleValue:(RCTMGLStyleValue *)styleValue
 {
-    layer.rasterResampling = styleValue.mglStyleValue;
+    layer.rasterResamplingMode = styleValue.mglStyleValue;
 }
 
 - (void)setRasterFadeDuration:(MGLRasterStyleLayer *)layer withReactStyleValue:(RCTMGLStyleValue *)styleValue


### PR DESCRIPTION
A proposed fix for https://github.com/react-native-mapbox/maps/issues/37.

When trying to build the latest version of @react-native-mapbox/maps in Xcode I get a "Semantic Issue" in RCTMGLStyle.m line 1470 'rasterResampling' is unavailable: Use rasterResamplingMode instead.

