### PR TITLE
Added missing turf plugin

### DIFF
--- a/android/rctmgl/build.gradle
+++ b/android/rctmgl/build.gradle
@@ -43,4 +43,5 @@ dependencies {
     // Mapbox plugins
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v7:0.9.0'
     implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v7:0.2.0'
+    implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:4.8.0'
 }


### PR DESCRIPTION
Building on Android currently gives an error about Turf functions being undefined.

This is because mapbox's turf plugin was missing from dependencies. This branch fixes that.